### PR TITLE
Make ThrottlingTroll usable in any .NET application

### DIFF
--- a/ThrottlingTroll.AspNet/ThrottlingTrollExtensions.cs
+++ b/ThrottlingTroll.AspNet/ThrottlingTrollExtensions.cs
@@ -38,7 +38,7 @@ namespace ThrottlingTroll
 
             if (opt.Log == null)
             {
-                var logger = builder.ApplicationServices.GetService<ILogger<ThrottlingTroll>>();
+                var logger = builder.ApplicationServices.GetService<ILogger<ThrottlingTrollCore>>();
                 opt.Log = logger == null ? null : (l, s) => logger.Log(l, s);
             }
 
@@ -53,7 +53,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<ThrottlingTrollConfig> GetThrottlingTrollConfig(this HttpContext context)
         {
-            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTroll.ThrottlingTrollConfigsContextKey];
+            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTrollCore.ThrottlingTrollConfigsContextKey];
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<LimitCheckResult> GetThrottlingTrollLimitCheckResults(this HttpContext context)
         {
-            return (List<LimitCheckResult>)context.Items[ThrottlingTroll.LimitCheckResultsContextKey];
+            return (List<LimitCheckResult>)context.Items[ThrottlingTrollCore.LimitCheckResultsContextKey];
         }
 
         private static ThrottlingTrollConfig CollectDeclarativeConfig(List<Assembly> assemblies)

--- a/ThrottlingTroll.AspNet/ThrottlingTrollMiddleware.cs
+++ b/ThrottlingTroll.AspNet/ThrottlingTrollMiddleware.cs
@@ -13,7 +13,7 @@ namespace ThrottlingTroll
     /// <summary>
     /// Implements ingress throttling
     /// </summary>
-    public class ThrottlingTrollMiddleware : ThrottlingTroll
+    public class ThrottlingTrollMiddleware : ThrottlingTrollCore
     {
         /// <summary>
         /// Ctor. Shold not be used externally, but needs to be public.

--- a/ThrottlingTroll.AzureFunctions/ThrottlingTrollExtensions.cs
+++ b/ThrottlingTroll.AzureFunctions/ThrottlingTrollExtensions.cs
@@ -117,7 +117,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<ThrottlingTrollConfig> GetThrottlingTrollConfig(this FunctionContext context)
         {
-            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTroll.ThrottlingTrollConfigsContextKey];
+            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTrollCore.ThrottlingTrollConfigsContextKey];
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<LimitCheckResult> GetThrottlingTrollLimitCheckResults(this FunctionContext context)
         {
-            return (List<LimitCheckResult>)context.Items[ThrottlingTroll.LimitCheckResultsContextKey];
+            return (List<LimitCheckResult>)context.Items[ThrottlingTrollCore.LimitCheckResultsContextKey];
         }
 
         private static ThrottlingTrollMiddleware CreateMiddleware(FunctionContext context, ThrottlingTrollOptions opt)
@@ -135,7 +135,7 @@ namespace ThrottlingTroll
 
             if (opt.Log == null)
             {
-                var logger = context.InstanceServices.GetService<ILogger<ThrottlingTroll>>();
+                var logger = context.InstanceServices.GetService<ILogger<ThrottlingTrollCore>>();
                 opt.Log = logger == null ? null : (l, s) => logger.Log(l, s);
             }
 

--- a/ThrottlingTroll.AzureFunctions/ThrottlingTrollMiddleware.cs
+++ b/ThrottlingTroll.AzureFunctions/ThrottlingTrollMiddleware.cs
@@ -16,7 +16,7 @@ namespace ThrottlingTroll
     /// <summary>
     /// Implements ingress throttling for Azure Functions
     /// </summary>
-    public class ThrottlingTrollMiddleware : ThrottlingTroll
+    public class ThrottlingTrollMiddleware : ThrottlingTrollCore
     {
         internal ThrottlingTrollMiddleware
         (

--- a/ThrottlingTroll.AzureFunctionsAspNet/ThrottlingTrollExtensions.cs
+++ b/ThrottlingTroll.AzureFunctionsAspNet/ThrottlingTrollExtensions.cs
@@ -87,7 +87,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<ThrottlingTrollConfig> GetThrottlingTrollConfig(this HttpContext context)
         {
-            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTroll.ThrottlingTrollConfigsContextKey];
+            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTrollCore.ThrottlingTrollConfigsContextKey];
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<ThrottlingTrollConfig> GetThrottlingTrollConfig(this FunctionContext context)
         {
-            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTroll.ThrottlingTrollConfigsContextKey];
+            return (List<ThrottlingTrollConfig>)context.Items[ThrottlingTrollCore.ThrottlingTrollConfigsContextKey];
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<LimitCheckResult> GetThrottlingTrollLimitCheckResults(this HttpContext context)
         {
-            return (List<LimitCheckResult>)context.Items[ThrottlingTroll.LimitCheckResultsContextKey];
+            return (List<LimitCheckResult>)context.Items[ThrottlingTrollCore.LimitCheckResultsContextKey];
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace ThrottlingTroll
         /// </summary>
         public static List<LimitCheckResult> GetThrottlingTrollLimitCheckResults(this FunctionContext context)
         {
-            return (List<LimitCheckResult>)context.Items[ThrottlingTroll.LimitCheckResultsContextKey];
+            return (List<LimitCheckResult>)context.Items[ThrottlingTrollCore.LimitCheckResultsContextKey];
         }
 
         private static ThrottlingTrollMiddleware CreateMiddleware(FunctionContext context, ThrottlingTrollOptions opt)
@@ -120,7 +120,7 @@ namespace ThrottlingTroll
 
             if (opt.Log == null)
             {
-                var logger = context.InstanceServices.GetService<ILogger<ThrottlingTroll>>();
+                var logger = context.InstanceServices.GetService<ILogger<ThrottlingTrollCore>>();
                 opt.Log = logger == null ? null : (l, s) => logger.Log(l, s);
             }
 

--- a/ThrottlingTroll.AzureFunctionsAspNet/ThrottlingTrollMiddleware.cs
+++ b/ThrottlingTroll.AzureFunctionsAspNet/ThrottlingTrollMiddleware.cs
@@ -15,7 +15,7 @@ namespace ThrottlingTroll
     /// <summary>
     /// Implements ingress throttling for Azure Functions with ASP.NET Core integration.
     /// </summary>
-    public class ThrottlingTrollMiddleware : ThrottlingTroll
+    public class ThrottlingTrollMiddleware : ThrottlingTrollCore
     {
         internal ThrottlingTrollMiddleware
         (

--- a/ThrottlingTroll.Core/Exceptions/ThrottlingTrollTooManyRequestsException.cs
+++ b/ThrottlingTroll.Core/Exceptions/ThrottlingTrollTooManyRequestsException.cs
@@ -5,8 +5,11 @@ namespace ThrottlingTroll
     /// <summary>
     /// A dedicated exception to propagate 429 status codes from Egress to Ingress
     /// </summary>
-    public class ThrottlingTrollTooManyRequestsException : Exception
+    internal class ThrottlingTrollTooManyRequestsException : Exception
     {
+        /// <summary>
+        /// Retry-After header value returned with the failed HTTP request.
+        /// </summary>
         public string RetryAfterHeaderValue { get; set; }
     }
 }

--- a/ThrottlingTroll.Core/IThrottlingTroll.cs
+++ b/ThrottlingTroll.Core/IThrottlingTroll.cs
@@ -1,0 +1,45 @@
+﻿
+using System;
+using System.Threading.Tasks;
+
+namespace ThrottlingTroll
+{
+    /// <summary>
+    /// Distributed rate limiter/throttler/circuit breaker for generic usage in any .NET application.
+    /// </summary>
+    public interface IThrottlingTroll
+    {
+        /// <summary>
+        /// Applies limits to a given arbitrary piece of code. When limit is exceeded, calls onLimitExceeded.
+        /// </summary>
+        /// <typeparam name="T">Return type of your code.</typeparam>
+        /// <param name="todo">Piece of code to be limited</param>
+        /// <param name="onLimitExceeded">
+        /// Will be called when a limit is exceeded. A <see cref="ThrottlingTrollContext"/> will be passed to it,
+        /// so that your code can see which rule(s) were exceeded.
+        /// </param>
+        /// <param name="methodName">
+        /// Optional arbitrary string identifying this particular execution flow. Will be passed to 
+        /// <see cref="IHttpRequestProxy.Method"/> property, so you can configure limits that will be applied
+        /// individually, based on this value. You can then also use it in your custom identityIdExtractors
+        /// and costExtractors.
+        /// <returns>Awaitable task</returns>
+        Task<T> WithThrottlingTroll<T>(Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded, string methodName = null);
+
+        /// <summary>
+        /// Applies limits to a given arbitrary piece of code. Expects an instance of <see cref="IHttpRequestProxy"/> to be passed.
+        /// You would need to make your custom implementation of it, which matches your scenario.
+        /// </summary>
+        /// <typeparam name="T">Return type of your code.</typeparam>
+        /// <param name="requestProxy">An instance of <see cref="IHttpRequestProxy"/></param>
+        /// <param name="todo"></param>
+        /// <param name="onLimitExceeded"></param>
+        /// <returns></returns>
+        Task<T> WithThrottlingTroll<T>(IHttpRequestProxy requestProxy, Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded);
+
+        /// <summary>
+        /// Returns the current <see cref="ThrottlingTrollConfig"/> snapshot, for your code's reference.
+        /// </summary>
+        Task<ThrottlingTrollConfig> GetCurrentConfig();
+    }
+}

--- a/ThrottlingTroll.Core/IThrottlingTroll.cs
+++ b/ThrottlingTroll.Core/IThrottlingTroll.cs
@@ -23,19 +23,53 @@ namespace ThrottlingTroll
         /// <see cref="IHttpRequestProxy.Method"/> property, so you can configure limits that will be applied
         /// individually, based on this value. You can then also use it in your custom identityIdExtractors
         /// and costExtractors.
+        /// </param>
         /// <returns>Awaitable task</returns>
         Task<T> WithThrottlingTroll<T>(Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded, string methodName = null);
+
+        /// <summary>
+        /// Applies limits to a given arbitrary piece of code. When limit is exceeded, calls onLimitExceeded.
+        /// </summary>
+        /// <param name="todo">Piece of code to be limited</param>
+        /// <param name="onLimitExceeded">
+        /// Will be called when a limit is exceeded. A <see cref="ThrottlingTrollContext"/> will be passed to it,
+        /// so that your code can see which rule(s) were exceeded.
+        /// </param>
+        /// <param name="methodName">
+        /// Optional arbitrary string identifying this particular execution flow. Will be passed to 
+        /// <see cref="IHttpRequestProxy.Method"/> property, so you can configure limits that will be applied
+        /// individually, based on this value. You can then also use it in your custom identityIdExtractors
+        /// and costExtractors.
+        /// </param>
+        /// <returns>Awaitable task</returns>
+        Task WithThrottlingTroll(Func<Task> todo, Func<ThrottlingTrollContext, Task> onLimitExceeded, string methodName = null);
 
         /// <summary>
         /// Applies limits to a given arbitrary piece of code. Expects an instance of <see cref="IHttpRequestProxy"/> to be passed.
         /// You would need to make your custom implementation of it, which matches your scenario.
         /// </summary>
         /// <typeparam name="T">Return type of your code.</typeparam>
-        /// <param name="requestProxy">An instance of <see cref="IHttpRequestProxy"/></param>
-        /// <param name="todo"></param>
-        /// <param name="onLimitExceeded"></param>
-        /// <returns></returns>
+        /// <param name="requestProxy">An instance of <see cref="IHttpRequestProxy"/>. You would need to implement it yourself.</param>
+        /// <param name="todo">Piece of code to be limited</param>
+        /// <param name="onLimitExceeded">
+        /// Will be called when a limit is exceeded. A <see cref="ThrottlingTrollContext"/> will be passed to it,
+        /// so that your code can see which rule(s) were exceeded.
+        /// </param>
+        /// <returns>Awaitable task</returns>
         Task<T> WithThrottlingTroll<T>(IHttpRequestProxy requestProxy, Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded);
+
+        /// <summary>
+        /// Applies limits to a given arbitrary piece of code. Expects an instance of <see cref="IHttpRequestProxy"/> to be passed.
+        /// You would need to make your custom implementation of it, which matches your scenario.
+        /// </summary>
+        /// <param name="requestProxy">An instance of <see cref="IHttpRequestProxy"/>. You would need to implement it yourself.</param>
+        /// <param name="todo">Piece of code to be limited</param>
+        /// <param name="onLimitExceeded">
+        /// Will be called when a limit is exceeded. A <see cref="ThrottlingTrollContext"/> will be passed to it,
+        /// so that your code can see which rule(s) were exceeded.
+        /// </param>
+        /// <returns>Awaitable task</returns>
+        Task WithThrottlingTroll(IHttpRequestProxy requestProxy, Func<Task> todo, Func<ThrottlingTrollContext, Task> onLimitExceeded);
 
         /// <summary>
         /// Returns the current <see cref="ThrottlingTrollConfig"/> snapshot, for your code's reference.

--- a/ThrottlingTroll.Core/RateLimitMethods/RateLimitMethod.cs
+++ b/ThrottlingTroll.Core/RateLimitMethods/RateLimitMethod.cs
@@ -3,6 +3,9 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 [assembly: InternalsVisibleTo("ThrottlingTroll.Core.Tests")]
+[assembly: InternalsVisibleTo("ThrottlingTroll.AspNet.Tests")]
+[assembly: InternalsVisibleTo("ThrottlingTroll.AzureFunctions.Tests")]
+[assembly: InternalsVisibleTo("ThrottlingTroll.AzureFunctionsAspNet.Tests")]
 
 namespace ThrottlingTroll
 {

--- a/ThrottlingTroll.Core/RequestProxies/GenericRequestProxy.cs
+++ b/ThrottlingTroll.Core/RequestProxies/GenericRequestProxy.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Primitives;
+using System.Collections.Generic;
+
+namespace ThrottlingTroll
+{
+    /// <summary>
+    /// Generic (dummy) implementation of <see cref="IHttpRequestProxy"/>, to be used for throttling any method calls.
+    /// </summary>
+    public class GenericRequestProxy : IHttpRequestProxy
+    {
+        /// <inheritdoc />
+        public string Uri { get; set; }
+
+        /// <inheritdoc />
+        public string UriWithoutQueryString { get; set; }
+
+        /// <inheritdoc />
+        public string Method { get; set; }
+
+        /// <inheritdoc />
+        public IDictionary<string, StringValues> Headers { get; set; } = new Dictionary<string, StringValues>();
+
+        /// <inheritdoc />
+        public IDictionary<object, object> RequestContextItems { get; set; }
+
+        /// <inheritdoc />
+        public void AppendToContextItem<T>(string key, List<T> list)
+        {
+        }
+    }
+}

--- a/ThrottlingTroll.Core/ThrottlingTroll.cs
+++ b/ThrottlingTroll.Core/ThrottlingTroll.cs
@@ -85,6 +85,24 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
+        public async Task WithThrottlingTroll(Func<Task> todo, Func<ThrottlingTrollContext, Task> onLimitExceeded, string methodName = null)
+        {
+            await this.WithThrottlingTroll
+            (
+                async () =>
+                {
+                    await todo();
+                    return 0;
+                },
+                async ctx =>
+                {
+                    await onLimitExceeded(ctx);
+                    return 0;
+                }
+            );
+        }
+
+        /// <inheritdoc />
         public async Task<T> WithThrottlingTroll<T>(IHttpRequestProxy requestProxy, Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded)
         {
             var cleanupRoutines = new List<Func<Task>>();
@@ -121,6 +139,25 @@ namespace ThrottlingTroll
             {
                 await Task.WhenAll(cleanupRoutines.Select(f => f()));
             }
+        }
+
+        /// <inheritdoc />
+        public async Task WithThrottlingTroll(IHttpRequestProxy requestProxy, Func<Task> todo, Func<ThrottlingTrollContext, Task> onLimitExceeded)
+        {
+            await this.WithThrottlingTroll
+            (
+                requestProxy,
+                async () =>
+                {
+                    await todo();
+                    return 0;
+                },
+                async ctx =>
+                {
+                    await onLimitExceeded(ctx);
+                    return 0;
+                }
+            );
         }
     }
 }

--- a/ThrottlingTroll.Core/ThrottlingTroll.cs
+++ b/ThrottlingTroll.Core/ThrottlingTroll.cs
@@ -1,569 +1,126 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace ThrottlingTroll
 {
     /// <summary>
-    /// Main functionality. The same for both ingress and egress.
+    /// Generic ThrottlingTroll that can be used in any .NET application.
     /// </summary>
-    public class ThrottlingTroll : IDisposable
+    public class ThrottlingTroll : ThrottlingTrollCore, IThrottlingTroll
     {
-        private readonly Action<LogLevel, string> _log;
-        private readonly ICounterStore _counterStore;
-        private readonly Func<IHttpRequestProxy, string> _identityIdExtractor;
-        private readonly Func<IHttpRequestProxy, long> _costExtractor;
-        private Task<ThrottlingTrollConfig> _getConfigTask;
-        private bool _disposed = false;
-        private TimeSpan _sleepTimeSpan = TimeSpan.FromMilliseconds(50);
-
-        #region Telemetry
-        internal static readonly ActivitySource ActivitySource = new ActivitySource("ThrottlingTroll");
-
-        internal static readonly Meter Meter = new Meter("ThrottlingTroll");
-
-        internal static readonly Counter<int> IngressRuleMatchesCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.ingress.rules_matched", "Counts how many rate limiting rules were matched by incoming requests");
-        internal static readonly Counter<int> IngressRequestsThrottledCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.ingress.requests_throttled", "Counts how many incoming requests were throttled (hit the limit)");
-
-        internal static readonly Counter<int> EgressRuleMatchesCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.egress.rules_matched", "Counts how many rate limiting rules were matched by outgoing requests");
-        internal static readonly Counter<int> EgressRequestsThrottledCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.egress.requests_throttled", "Counts how many outgoing requests were throttled (hit the limit)");
-
-        internal static readonly Counter<int> FailuresCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.internal_failures", "Counts how many internal failures ThrottlingTroll experienced");
-        internal static readonly Counter<int> GetConfigFuncSuccessesCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.get_config_func_successes", "Counts how many times ThrottlingTrollOptions.GetConfigFunc was successfully called");
-        internal static readonly Counter<int> GetConfigFuncFailuresCounter = 
-            Meter.CreateCounter<int>("throttlingtroll.get_config_func_failures", "Counts how many times ThrottlingTrollOptions.GetConfigFunc failed");
-        #endregion
-
         /// <summary>
-        /// Ctor
+        /// Initializes a new instance of the <see cref="ThrottlingTroll"/> class.
         /// </summary>
-        protected internal ThrottlingTroll
+        /// <param name="getConfigFunc"><see cref="ThrottlingTrollConfig"/> getter. Will be called every intervalToReloadConfigInSeconds.</param>
+        /// <param name="intervalToReloadConfigInSeconds">When set to > 0, getConfigFunc will be called periodically with this interval. This allows you to dynamically change throttling rules and limits without restarting the service.</param>
+        /// <param name="counterStore">An instance of <see cref="ICounterStore"/> to be used for storing counters.</param>
+        /// <param name="identityIdExtractor">Identity ID extraction routine to be used for extracting Identity IDs from requests. null means all requests are coming from the same identity.</param>
+        /// <param name="costExtractor">Request's cost extraction routine. The default cost (weight) of a request is 1, but this routine allows to override that. null means each request costs 1.</param>
+        /// <param name="log">Logging routine.</param>
+        public ThrottlingTroll
         (
-            Action<LogLevel, string> log,
-            ICounterStore counterStore,
             Func<Task<ThrottlingTrollConfig>> getConfigFunc,
+            int intervalToReloadConfigInSeconds,
+            ICounterStore counterStore,
             Func<IHttpRequestProxy, string> identityIdExtractor,
             Func<IHttpRequestProxy, long> costExtractor,
-            int intervalToReloadConfigInSeconds = 0
+            Action<LogLevel, string> log
         )
+            : base(log, counterStore, getConfigFunc, identityIdExtractor, costExtractor, intervalToReloadConfigInSeconds)
         {
-            ArgumentNullException.ThrowIfNull(counterStore);
-            ArgumentNullException.ThrowIfNull(getConfigFunc);
-
-            this._identityIdExtractor = identityIdExtractor;
-            this._costExtractor = costExtractor;
-            this._counterStore = counterStore;
-            this._log = log ?? ((l, s) => { });
-            this._counterStore.Log = this._log;
-
-            this.InitGetConfigTask(getConfigFunc, intervalToReloadConfigInSeconds);
         }
 
         /// <summary>
-        /// A key under which a <see cref="List{LimitCheckResult}"/> will be placed to HttpContext.Items or FunctionContext.Items
+        /// Initializes a new instance of the <see cref="ThrottlingTroll"/> class.
         /// </summary>
-        public static readonly string LimitCheckResultsContextKey = "ThrottlingTrollLimitCheckResultsContextKey";
-
-        /// <summary>
-        /// A key under which a <see cref="List{ThrottlingTrollConfig}"/> will be placed to HttpContext.Items or FunctionContext.Items
-        /// </summary>
-        public static readonly string ThrottlingTrollConfigsContextKey = "ThrottlingTrollConfigsContextKey";
-
-        /// <summary>
-        /// Marks this instance as disposed
-        /// </summary>
-        public void Dispose()
+        /// <param name="config">An instance of <see cref="ThrottlingTrollConfig"/> with rules and limits defined.</param>
+        /// <param name="counterStore">An instance of <see cref="ICounterStore"/> to be used for storing counters.</param>
+        /// <param name="identityIdExtractor">Identity ID extraction routine to be used for extracting Identity IDs from requests. null means all requests are coming from the same identity.</param>
+        /// <param name="costExtractor">Request's cost extraction routine. The default cost (weight) of a request is 1, but this routine allows to override that. null means each request costs 1.</param>
+        public ThrottlingTroll
+        (
+            ThrottlingTrollConfig config,
+            ICounterStore counterStore,
+            Func<IHttpRequestProxy, string> identityIdExtractor,
+            Func<IHttpRequestProxy, long> costExtractor
+        )
+            : base((l, s) => { }, counterStore, () => Task.FromResult(config), identityIdExtractor, costExtractor, 0)
         {
-            this._disposed = true;
         }
 
         /// <summary>
-        /// Returns the current <see cref="ThrottlingTrollConfig"/> snapshot
+        /// Initializes a new instance of the <see cref="ThrottlingTroll"/> class.
         /// </summary>
-        protected async Task<ThrottlingTrollConfig> GetCurrentConfig()
+        /// <param name="config">An instance of <see cref="ThrottlingTrollConfig"/> with rules and limits defined.</param>
+        /// <param name="counterStore">An instance of <see cref="ICounterStore"/> to be used for storing counters.</param>
+        public ThrottlingTroll(ThrottlingTrollConfig config, ICounterStore counterStore)
+            : base((l, s) => { }, counterStore, () => Task.FromResult(config), null, null, 0)
         {
-            // Always getting the current value from the task. Once completed, tasks cache and return the same resulting object anyway.
-            var config = await this._getConfigTask;
-
-            // If it is the same object, just returning it
-            if (config == this._currentConfig)
-            {
-                return config;
-            }
-
-            // The object has changed (probably, because the task was re-executed), so we need to re-apply global settings to it
-
-            if (config.Rules != null)
-            {
-                foreach (var rule in config.Rules)
-                {
-                    rule.IdentityIdExtractor ??= this._identityIdExtractor;
-
-                    rule.CostExtractor ??= this._costExtractor;
-                }
-            }
-
-            if (config.AllowList != null)
-            {
-                foreach (var rule in config.AllowList)
-                {
-                    if (rule.IdentityIdExtractor == null)
-                    {
-                        rule.IdentityIdExtractor = this._identityIdExtractor;
-                    }
-                }
-            }
-
-            // This must be done at the very end of this method
-            this._currentConfig = config;
-            return config;
         }
 
         /// <summary>
-        /// Checks if ingress limit is exceeded for a given request.
-        /// Also checks whether there're any <see cref="ThrottlingTrollTooManyRequestsException"/>s from egress.
-        /// Returns a list of check results for rules that this request matched.
+        /// Initializes a new instance of the <see cref="ThrottlingTroll"/> class.
         /// </summary>
-        protected internal async Task<List<LimitCheckResult>> IsIngressOrEgressExceededAsync(IHttpRequestProxy request, List<Func<Task>> cleanupRoutines, Func<Task> nextAction)
+        /// <param name="config">Instance of <see cref="ThrottlingTrollConfig"/> with rules and limits defined.</param>
+        public ThrottlingTroll(ThrottlingTrollConfig config)
+            : base((l, s) => { }, new MemoryCacheCounterStore(), () => Task.FromResult(config), null, null, 0)
         {
-            #region Telemetry
-            // Important to create this activity _before_ calling IsExceededAsync
-            using var activity = ActivitySource.StartActivity("ThrottlingTroll.Ingress");
-            #endregion
+        }
 
-            // First trying ingress
-            var checkList = await this.IsExceededAsync(request, cleanupRoutines);
+        /// <inheritdoc />
+        public new Task<ThrottlingTrollConfig> GetCurrentConfig()
+        {
+            return base.GetCurrentConfig();
+        }
 
-            #region Telemetry
-            foreach (var checkResult in checkList)
-            {
-                IngressRuleMatchesCounter.Add(1, new TagList { { "throttlingtroll.rule", checkResult.Rule.GetNameForTelemetry() }, { "throttlingtroll.counter_id", checkResult.CounterId } });
+        /// <inheritdoc />
+        public Task<T> WithThrottlingTroll<T>(Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded, string methodName = null)
+        {
+            var requestProxy = new GenericRequestProxy { Method = methodName };
 
-                if (checkResult.RequestsRemaining < 0)
-                {
-                    string msg = "Request limit exceeded";
-                    activity?.AddTag("Result", msg);
-                    activity?.SetStatus(ActivityStatusCode.Error, msg);
+            return this.WithThrottlingTroll(requestProxy, todo, onLimitExceeded);
+        }
 
-                    IngressRequestsThrottledCounter.Add(1, new TagList { { "throttlingtroll.rule", checkResult.Rule.GetNameForTelemetry() }, { "throttlingtroll.counter_id", checkResult.CounterId } });
-                }
-            }
-            #endregion
-
-            if (checkList.Any(r => r.RequestsRemaining < 0))
-            {
-                // If limit exceeded, returning immediately
-                return checkList;
-            }
-
-            // Also trying to propagate egress to ingress
+        /// <inheritdoc />
+        public async Task<T> WithThrottlingTroll<T>(IHttpRequestProxy requestProxy, Func<Task<T>> todo, Func<ThrottlingTrollContext, Task<T>> onLimitExceeded)
+        {
+            var cleanupRoutines = new List<Func<Task>>();
             try
             {
-                await nextAction();
+                var checkList = await this.IsExceededAsync(requestProxy, cleanupRoutines);
+                var limitsExceeded = checkList.Where(r => r.RequestsRemaining < 0).ToList();
 
-                #region Telemetry
-                string msg = "Request processed successfully";
-                activity?.AddTag("Result", msg);
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                #endregion
-            }
-            catch (ThrottlingTrollTooManyRequestsException throttlingEx)
-            {
-                // Catching propagated exception from egress
-                checkList.Add(new LimitCheckResult(throttlingEx.RetryAfterHeaderValue));
-
-                #region Telemetry
-                activity?.AddTag("RetryAfterHeaderFromEgress", throttlingEx.RetryAfterHeaderValue);
-                string msg = "TooManyRequests error propagated from egress";
-                activity?.AddTag("Result", msg);
-                activity?.SetStatus(ActivityStatusCode.Error, msg);
-                #endregion
-            }
-            catch (AggregateException ex)
-            {
-                // Catching propagated exception from egress as AggregateException
-                // TODO: refactor to LINQ
-
-                ThrottlingTrollTooManyRequestsException throttlingEx = null;
-
-                foreach (var exx in ex.Flatten().InnerExceptions)
+                if (limitsExceeded.Any())
                 {
-                    throttlingEx = exx as ThrottlingTrollTooManyRequestsException;
-                    if (throttlingEx != null)
+                    var ctx = new ThrottlingTrollContext { LimitCheckResults = checkList };
+
+                    var result = await onLimitExceeded(ctx);
+
+                    if (!ctx.ShouldContinueAsNormal)
                     {
-                        checkList.Add(new LimitCheckResult(throttlingEx.RetryAfterHeaderValue));
-
-                        #region Telemetry
-                        activity?.AddTag("RetryAfterHeaderFromEgress", throttlingEx.RetryAfterHeaderValue);
-                        string msg = "TooManyRequests error propagated from egress";
-                        activity?.AddTag("Result", msg);
-                        activity?.SetStatus(ActivityStatusCode.Error, msg);
-                        #endregion
-
-                        break;
+                        return result;
                     }
                 }
 
-                if (throttlingEx == null)
+                try
                 {
+                    return await todo();
+                }
+                catch (Exception ex)
+                {
+                    // Adding/removing internal circuit breaking rules
+                    await this.CheckAndBreakTheCircuit(requestProxy, null, ex);
+
                     throw;
                 }
             }
-
-            return checkList;
-        }
-
-        /// <summary>
-        /// Checks which limits were exceeded for a given request.
-        /// Returns a list of check results for rules that this request matched.
-        /// </summary>
-        protected internal async Task<List<LimitCheckResult>> IsExceededAsync(IHttpRequestProxy request, List<Func<Task>> cleanupRoutines)
-        {
-            var result = new List<LimitCheckResult>();
-
-            ThrottlingTrollConfig config;
-            try
+            finally
             {
-                config = await this.GetCurrentConfig();
-            }
-            catch (Exception ex)
-            {
-                this._log(LogLevel.Error, $"ThrottlingTroll failed to get its config. {ex}");
-
-                return result;
-            }
-
-            // Adding the current ThrottlingTrollConfig, for client's reference. Doing this _before_ any extractors are called.
-            this.AppendToContextItem(request, ThrottlingTrollConfigsContextKey, new List<ThrottlingTrollConfig> { config });
-
-            if (config.Rules == null)
-            {
-                return result;
-            }
-
-            bool allowListed = false;
-            var dtStart = DateTimeOffset.UtcNow;
-
-            // Still need to check all limits, so that all counters get updated
-            foreach (var limit in config.Rules)
-            {
-                #region Telemetry
-                using var activity = ActivitySource.StartActivity($"ThrottlingTroll.Rule.{limit.GetNameForTelemetry()}");
-                limit.AddTagsToActivity(activity);
-                #endregion
-
-                try
-                {
-                    // First checking if request allowlisted
-                    if (!limit.IgnoreAllowList && config.AllowList != null && config.AllowList.Any(filter => filter.IsMatch(request)))
-                    {
-                        allowListed = true;
-
-                        #region Telemetry
-                        string msg = "Request allowlisted";
-                        activity?.AddTag("Result", msg);
-                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
-                        #endregion
-
-                        continue;
-                    }
-
-                    long requestCost = limit.GetCost(request);
-
-                    var limitCheckResult = await limit.IsExceededAsync(request, requestCost, this._counterStore, config.UniqueName, this._log);
-
-                    if (limitCheckResult == null)
-                    {
-                        // The request did not match this rule
-
-                        #region Telemetry
-                        string msg = "Request did not match this rule";
-                        activity?.AddTag("Result", msg);
-                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
-                        #endregion
-
-                        continue;
-                    }
-
-                    #region Telemetry
-                    activity?.AddTag("RequestCost", requestCost);
-                    limitCheckResult.AddTagsToActivity(activity);
-                    #endregion
-
-                    if ((limitCheckResult.RequestsRemaining < 0) && limit.MaxDelayInSeconds > 0)
-                    {
-                        #region Telemetry
-                        using var waitingActivity = ActivitySource.StartActivity($"ThrottlingTroll.Waiting");
-                        #endregion
-
-                        // Doing the delay logic
-                        while ((DateTimeOffset.UtcNow - dtStart).TotalSeconds <= limit.MaxDelayInSeconds)
-                        {
-                            if (!await limit.IsStillExceededAsync(this._counterStore, limitCheckResult.CounterId, request))
-                            {
-                                // Doing double-check
-                                limitCheckResult = await limit.IsExceededAsync(request, requestCost, this._counterStore, config.UniqueName, this._log);
-
-                                if (limitCheckResult.RequestsRemaining >= 0)
-                                {
-                                    break;
-                                }
-                            }
-
-                            await Task.Delay(this._sleepTimeSpan);
-                        }
-
-                        #region Telemetry
-                        if (limitCheckResult.RequestsRemaining >= 0)
-                        {
-                            waitingActivity?.SetStatus(ActivityStatusCode.Ok, "Waiting finished");
-                        }
-                        else
-                        {
-                            waitingActivity?.SetStatus(ActivityStatusCode.Error, "Waiting timed out");
-                        }
-                        #endregion
-                    }
-
-                    if (limitCheckResult.RequestsRemaining >= 0)
-                    {
-                        // Decrementing this counter at the end of request processing
-                        cleanupRoutines.Add(() => limit.OnRequestProcessingFinished(this._counterStore, limitCheckResult.CounterId, requestCost, this._log, request));
-                    }
-
-                    result.Add(limitCheckResult);
-
-                    #region Telemetry
-                    if (limitCheckResult.RequestsRemaining >= 0)
-                    {
-                        string msg = $"Requests remaining: {limitCheckResult.RequestsRemaining}";
-                        activity?.AddTag("Result", msg);
-                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
-
-                        activity?.SetStatus(ActivityStatusCode.Ok);
-                    }
-                    else
-                    {
-                        string msg = "Request limit exceeded";
-                        activity?.AddTag("Result", msg);
-                        activity?.SetStatus(ActivityStatusCode.Error, msg);
-                    }
-                    #endregion
-                }
-                catch (Exception ex)
-                {
-                    string msg = $"ThrottlingTroll failed. {ex}";
-                    this._log(LogLevel.Error, msg);
-
-                    #region Telemetry
-                    activity?.AddTag("Result", msg);
-                    activity?.SetStatus(ActivityStatusCode.Error, msg);
-
-                    FailuresCounter.Add(1, new TagList { { "throttlingtroll.rule", limit.GetNameForTelemetry() } });
-                    #endregion
-
-                    if (limit.ShouldThrowOnFailures)
-                    {
-                        throw;
-                    }
-                }
-            }
-
-            if (allowListed)
-            {
-                this._log(LogLevel.Information, $"ThrottlingTroll allowlisted {request.Method} {request.UriWithoutQueryString}");
-            }
-
-            // Adding check results as an item to the HttpContext, so that client's code can use it
-            this.AppendToContextItem(request, LimitCheckResultsContextKey, result);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Applies the CircuitBreaker logic
-        /// </summary>
-        protected internal async Task CheckAndBreakTheCircuit(IHttpRequestProxy request, IHttpResponseProxy response, Exception exception)
-        {
-            ThrottlingTrollConfig config;
-            try
-            {
-                config = await this.GetCurrentConfig();
-            }
-            catch (Exception ex)
-            {
-                this._log(LogLevel.Error, $"ThrottlingTroll failed to get its config. {ex}");
-
-                return;
-            }
-
-            if (config?.Rules == null)
-            {
-                return;
-            }
-
-            // Checking all CircuitBreaker rules that this request matches
-            foreach (var limit in config.Rules)
-            {
-                #region Telemetry
-                Activity activity = null;
-                #endregion
-
-                try
-                {
-                    var circuitBreakerMethod = limit.LimitMethod as CircuitBreakerRateLimitMethod;
-                    if (circuitBreakerMethod == null || !limit.IsMatch(request))
-                    {
-                        continue;
-                    }
-
-                    string uniqueCacheKey = limit.GetUniqueCacheKey(request, config.UniqueName);
-
-                    #region Telemetry
-                    activity = ActivitySource.StartActivity($"ThrottlingTroll.CircuitBreakerRule.{limit.GetNameForTelemetry()}");
-                    activity?.AddTag($"CounterId", uniqueCacheKey);
-                    limit.AddTagsToActivity(activity);
-                    #endregion
-
-                    if (circuitBreakerMethod.IsFailed(response, exception))
-                    {
-                        // Checking the failure count
-
-                        var now = DateTime.UtcNow;
-
-                        var ttl = now - TimeSpan.FromMilliseconds(now.Millisecond) + TimeSpan.FromSeconds(circuitBreakerMethod.IntervalInSeconds);
-
-                        // Better to use a separate counter for failures, because Trial mode increments the counter regardless of the output.
-                        // We don't want to count successes as failures, that would distort the picture.
-                        string failureCountCacheKey = $"{uniqueCacheKey}|CircuitBreakerFailureCount";
-
-                        long failureCount = await this._counterStore.IncrementAndGetAsync(failureCountCacheKey, 1, ttl, 1, request);
-
-                        if (failureCount > circuitBreakerMethod.PermitLimit)
-                        {
-                            // If failure limit is exceeded, placing this limit into Trial mode, which limits request rate to 1 request per trial interval
-                            CircuitBreakerRateLimitMethod.PutIntoTrial(uniqueCacheKey);
-
-                            #region Telemetry
-                            string msg = $"Went into trial mode";
-                            activity?.AddTag("Result", msg);
-                            activity?.AddTag($"FailureCount", failureCount);
-                            activity?.SetStatus(ActivityStatusCode.Error, msg);
-                            #endregion
-                        }
-                        else
-                        {
-                            #region Telemetry
-                            string msg = $"Failure count so far: {failureCount}";
-                            activity?.AddTag("Result", msg);
-                            activity?.AddTag($"FailureCount", failureCount);
-                            activity?.SetStatus(ActivityStatusCode.Ok, msg);
-                            #endregion
-                        }
-                    }
-                    else
-                    {
-                        // Just lifting the trial mode
-                        CircuitBreakerRateLimitMethod.ReleaseFromTrial(uniqueCacheKey);
-
-                        #region Telemetry
-                        string msg = "Released from trial mode";
-                        activity?.AddTag("Result", msg);
-                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
-                        #endregion
-                    }
-                }
-                catch (Exception ex)
-                {
-                    string msg = $"ThrottlingTroll failed. {ex}";
-                    this._log(LogLevel.Error, msg);
-
-                    #region Telemetry
-                    activity?.AddTag("Result", msg);
-                    activity?.SetStatus(ActivityStatusCode.Error, msg);
-                    #endregion
-
-                    if (limit.ShouldThrowOnFailures)
-                    {
-                        throw;
-                    }
-                }
-                finally
-                {
-                    #region Telemetry
-                    activity?.Dispose();
-                    #endregion
-                }
+                await Task.WhenAll(cleanupRoutines.Select(f => f()));
             }
         }
-
-        /// <summary>
-        /// Initializes this._getConfigTask and also makes it reinitialized every intervalToReloadConfigInSeconds
-        /// </summary>
-        private void InitGetConfigTask(Func<Task<ThrottlingTrollConfig>> getConfigFunc, int intervalToReloadConfigInSeconds)
-        {
-            if (this._disposed)
-            {
-                return;
-            }
-
-            if (intervalToReloadConfigInSeconds <= 0)
-            {
-                this._getConfigTask = getConfigFunc();
-
-                return;
-            }
-
-            var task = getConfigFunc();
-
-            task.ContinueWith(async t =>
-            {
-                #region Telemetry
-                if (t.IsFaulted)
-                {
-                    GetConfigFuncFailuresCounter.Add(1);
-                }
-                else if (t.IsCompletedSuccessfully)
-                {
-                    GetConfigFuncSuccessesCounter.Add(1);
-                }
-                #endregion
-
-                await Task.Delay(TimeSpan.FromSeconds(intervalToReloadConfigInSeconds));
-
-                this.InitGetConfigTask(getConfigFunc, intervalToReloadConfigInSeconds);
-            });
-
-            this._getConfigTask = task;
-        }
-
-        private void AppendToContextItem<T>(IHttpRequestProxy request, string key, List<T> list)
-        {
-            try
-            {
-                // Adding check results as an item to the HttpContext, so that client's code can use it
-                request.AppendToContextItem(key, list);
-            }
-            catch (ObjectDisposedException ex)
-            {
-                // At this point HttpContext might be already disposed, and in that case this happens.
-                this._log(LogLevel.Warning, $"ThrottlingTroll failed to populate request context with LimitCheckResults. {ex}");
-            }
-        }
-
-        /// <summary>
-        /// Caching the current config value, so that we don't need to re-apply global settings every time
-        /// </summary>
-        private ThrottlingTrollConfig _currentConfig;
     }
 }

--- a/ThrottlingTroll.Core/ThrottlingTrollContext.cs
+++ b/ThrottlingTroll.Core/ThrottlingTrollContext.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ThrottlingTroll
+{
+    /// <summary>
+    /// Context passed to the onLimitExceeded handler.
+    /// </summary>
+    public class ThrottlingTrollContext
+    {
+        internal ThrottlingTrollContext() { }
+
+        /// <summary>
+        /// Results of checking all applicable rules. Rules that were exceeded have <see cref="LimitCheckResult.RequestsRemaining"/> below zero.
+        /// </summary>
+        public IList<LimitCheckResult> LimitCheckResults { get; internal set; }
+
+        /// <summary>
+        /// Information about the limit that was exceeded.
+        /// </summary>
+        public LimitCheckResult ExceededLimit
+        {
+            get => this.LimitCheckResults
+                .Where(r => r.RequestsRemaining < 0)
+                // Sorting by the suggested RetryAfter header value (which is expected to be in seconds) in descending order
+                .OrderByDescending(r => r.RetryAfterInSeconds)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Set this to true, if you want ThrottlingTroll to continue processing the call as normal
+        /// even when a limit was exceeded.
+        /// </summary>
+        public bool ShouldContinueAsNormal { get; set; }
+    }
+}

--- a/ThrottlingTroll.Core/ThrottlingTrollCore.cs
+++ b/ThrottlingTroll.Core/ThrottlingTrollCore.cs
@@ -1,0 +1,575 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ThrottlingTroll
+{
+    /// <summary>
+    /// Main functionality. The same for both ingress and egress.
+    /// </summary>
+    public class ThrottlingTrollCore : IDisposable
+    {
+        private readonly Action<LogLevel, string> _log;
+        private readonly ICounterStore _counterStore;
+        private readonly Func<IHttpRequestProxy, string> _identityIdExtractor;
+        private readonly Func<IHttpRequestProxy, long> _costExtractor;
+        private Task<ThrottlingTrollConfig> _getConfigTask;
+        private bool _disposed = false;
+        private TimeSpan _sleepTimeSpan = TimeSpan.FromMilliseconds(50);
+
+        #region Telemetry
+        internal static readonly ActivitySource ActivitySource = new ActivitySource("ThrottlingTroll");
+
+        internal static readonly Meter Meter = new Meter("ThrottlingTroll");
+
+        internal static readonly Counter<int> IngressRuleMatchesCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.ingress.rules_matched", "Counts how many rate limiting rules were matched by incoming requests");
+        internal static readonly Counter<int> IngressRequestsThrottledCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.ingress.requests_throttled", "Counts how many incoming requests were throttled (hit the limit)");
+
+        internal static readonly Counter<int> EgressRuleMatchesCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.egress.rules_matched", "Counts how many rate limiting rules were matched by outgoing requests");
+        internal static readonly Counter<int> EgressRequestsThrottledCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.egress.requests_throttled", "Counts how many outgoing requests were throttled (hit the limit)");
+
+        internal static readonly Counter<int> FailuresCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.internal_failures", "Counts how many internal failures ThrottlingTroll experienced");
+        internal static readonly Counter<int> GetConfigFuncSuccessesCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.get_config_func_successes", "Counts how many times ThrottlingTrollOptions.GetConfigFunc was successfully called");
+        internal static readonly Counter<int> GetConfigFuncFailuresCounter = 
+            Meter.CreateCounter<int>("throttlingtroll.get_config_func_failures", "Counts how many times ThrottlingTrollOptions.GetConfigFunc failed");
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThrottlingTrollCore"/> class.
+        /// </summary>
+        /// <param name="log">Logging routine.</param>
+        /// <param name="counterStore">An instance of <see cref="ICounterStore"/> to be used.</param>
+        /// <param name="getConfigFunc"><see cref="ThrottlingTrollConfig"/> getter. Will be called every intervalToReloadConfigInSeconds.</param>
+        /// <param name="identityIdExtractor">Identity ID extraction routine to be used for extracting Identity IDs from requests.</param>
+        /// <param name="costExtractor">Request's cost extraction routine. The default cost (weight) of a request is 1, but this routine allows to override that.</param>
+        /// <param name="intervalToReloadConfigInSeconds">When set to > 0, getConfigFunc will be called periodically with this interval. This allows you to dynamically change throttling rules and limits without restarting the service.</param>
+        public ThrottlingTrollCore
+        (
+            Action<LogLevel, string> log,
+            ICounterStore counterStore,
+            Func<Task<ThrottlingTrollConfig>> getConfigFunc,
+            Func<IHttpRequestProxy, string> identityIdExtractor,
+            Func<IHttpRequestProxy, long> costExtractor,
+            int intervalToReloadConfigInSeconds = 0
+        )
+        {
+            ArgumentNullException.ThrowIfNull(counterStore);
+            ArgumentNullException.ThrowIfNull(getConfigFunc);
+
+            this._identityIdExtractor = identityIdExtractor;
+            this._costExtractor = costExtractor;
+            this._counterStore = counterStore;
+            this._log = log ?? ((l, s) => { });
+            this._counterStore.Log = this._log;
+
+            this.InitGetConfigTask(getConfigFunc, intervalToReloadConfigInSeconds);
+        }
+
+        /// <summary>
+        /// A key under which a <see cref="List{LimitCheckResult}"/> will be placed to HttpContext.Items or FunctionContext.Items
+        /// </summary>
+        public static readonly string LimitCheckResultsContextKey = "ThrottlingTrollLimitCheckResultsContextKey";
+
+        /// <summary>
+        /// A key under which a <see cref="List{ThrottlingTrollConfig}"/> will be placed to HttpContext.Items or FunctionContext.Items
+        /// </summary>
+        public static readonly string ThrottlingTrollConfigsContextKey = "ThrottlingTrollConfigsContextKey";
+
+        /// <summary>
+        /// Marks this instance as disposed
+        /// </summary>
+        public void Dispose()
+        {
+            this._disposed = true;
+        }
+
+        /// <summary>
+        /// Returns the current <see cref="ThrottlingTrollConfig"/> snapshot
+        /// </summary>
+        protected async Task<ThrottlingTrollConfig> GetCurrentConfig()
+        {
+            // Always getting the current value from the task. Once completed, tasks cache and return the same resulting object anyway.
+            var config = await this._getConfigTask;
+
+            // If it is the same object, just returning it
+            if (config == this._currentConfig)
+            {
+                return config;
+            }
+
+            // The object has changed (probably, because the task was re-executed), so we need to re-apply global settings to it
+
+            if (config.Rules != null)
+            {
+                foreach (var rule in config.Rules)
+                {
+                    rule.IdentityIdExtractor ??= this._identityIdExtractor;
+
+                    rule.CostExtractor ??= this._costExtractor;
+                }
+            }
+
+            if (config.AllowList != null)
+            {
+                foreach (var rule in config.AllowList)
+                {
+                    if (rule.IdentityIdExtractor == null)
+                    {
+                        rule.IdentityIdExtractor = this._identityIdExtractor;
+                    }
+                }
+            }
+
+            // This must be done at the very end of this method
+            this._currentConfig = config;
+            return config;
+        }
+
+        /// <summary>
+        /// Checks if ingress limit is exceeded for a given request.
+        /// Also checks whether there're any <see cref="ThrottlingTrollTooManyRequestsException"/>s from egress.
+        /// Returns a list of check results for rules that this request matched.
+        /// </summary>
+        protected internal async Task<List<LimitCheckResult>> IsIngressOrEgressExceededAsync(IHttpRequestProxy request, List<Func<Task>> cleanupRoutines, Func<Task> nextAction)
+        {
+            #region Telemetry
+            // Important to create this activity _before_ calling IsExceededAsync
+            using var activity = ActivitySource.StartActivity("ThrottlingTroll.Ingress");
+            #endregion
+
+            // First trying ingress
+            var checkList = await this.IsExceededAsync(request, cleanupRoutines);
+
+            #region Telemetry
+            foreach (var checkResult in checkList)
+            {
+                IngressRuleMatchesCounter.Add(1, new TagList { { "throttlingtroll.rule", checkResult.Rule.GetNameForTelemetry() }, { "throttlingtroll.counter_id", checkResult.CounterId } });
+
+                if (checkResult.RequestsRemaining < 0)
+                {
+                    string msg = "Request limit exceeded";
+                    activity?.AddTag("Result", msg);
+                    activity?.SetStatus(ActivityStatusCode.Error, msg);
+
+                    IngressRequestsThrottledCounter.Add(1, new TagList { { "throttlingtroll.rule", checkResult.Rule.GetNameForTelemetry() }, { "throttlingtroll.counter_id", checkResult.CounterId } });
+                }
+            }
+            #endregion
+
+            if (checkList.Any(r => r.RequestsRemaining < 0))
+            {
+                // If limit exceeded, returning immediately
+                return checkList;
+            }
+
+            // Also trying to propagate egress to ingress
+            try
+            {
+                await nextAction();
+
+                #region Telemetry
+                string msg = "Request processed successfully";
+                activity?.AddTag("Result", msg);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+                #endregion
+            }
+            catch (ThrottlingTrollTooManyRequestsException throttlingEx)
+            {
+                // Catching propagated exception from egress
+                checkList.Add(new LimitCheckResult(throttlingEx.RetryAfterHeaderValue));
+
+                #region Telemetry
+                activity?.AddTag("RetryAfterHeaderFromEgress", throttlingEx.RetryAfterHeaderValue);
+                string msg = "TooManyRequests error propagated from egress";
+                activity?.AddTag("Result", msg);
+                activity?.SetStatus(ActivityStatusCode.Error, msg);
+                #endregion
+            }
+            catch (AggregateException ex)
+            {
+                // Catching propagated exception from egress as AggregateException
+                // TODO: refactor to LINQ
+
+                ThrottlingTrollTooManyRequestsException throttlingEx = null;
+
+                foreach (var exx in ex.Flatten().InnerExceptions)
+                {
+                    throttlingEx = exx as ThrottlingTrollTooManyRequestsException;
+                    if (throttlingEx != null)
+                    {
+                        checkList.Add(new LimitCheckResult(throttlingEx.RetryAfterHeaderValue));
+
+                        #region Telemetry
+                        activity?.AddTag("RetryAfterHeaderFromEgress", throttlingEx.RetryAfterHeaderValue);
+                        string msg = "TooManyRequests error propagated from egress";
+                        activity?.AddTag("Result", msg);
+                        activity?.SetStatus(ActivityStatusCode.Error, msg);
+                        #endregion
+
+                        break;
+                    }
+                }
+
+                if (throttlingEx == null)
+                {
+                    throw;
+                }
+            }
+
+            return checkList;
+        }
+
+        /// <summary>
+        /// Checks which limits were exceeded for a given request.
+        /// Returns a list of check results for rules that this request matched.
+        /// </summary>
+        protected internal async Task<List<LimitCheckResult>> IsExceededAsync(IHttpRequestProxy request, List<Func<Task>> cleanupRoutines)
+        {
+            var result = new List<LimitCheckResult>();
+
+            ThrottlingTrollConfig config;
+            try
+            {
+                config = await this.GetCurrentConfig();
+            }
+            catch (Exception ex)
+            {
+                this._log(LogLevel.Error, $"ThrottlingTroll failed to get its config. {ex}");
+
+                return result;
+            }
+
+            // Adding the current ThrottlingTrollConfig, for client's reference. Doing this _before_ any extractors are called.
+            this.AppendToContextItem(request, ThrottlingTrollConfigsContextKey, new List<ThrottlingTrollConfig> { config });
+
+            if (config.Rules == null)
+            {
+                return result;
+            }
+
+            bool allowListed = false;
+            var dtStart = DateTimeOffset.UtcNow;
+
+            // Still need to check all limits, so that all counters get updated
+            foreach (var limit in config.Rules)
+            {
+                #region Telemetry
+                using var activity = ActivitySource.StartActivity($"ThrottlingTroll.Rule.{limit.GetNameForTelemetry()}");
+                limit.AddTagsToActivity(activity);
+                #endregion
+
+                try
+                {
+                    // First checking if request allowlisted
+                    if (!limit.IgnoreAllowList && config.AllowList != null && config.AllowList.Any(filter => filter.IsMatch(request)))
+                    {
+                        allowListed = true;
+
+                        #region Telemetry
+                        string msg = "Request allowlisted";
+                        activity?.AddTag("Result", msg);
+                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
+                        #endregion
+
+                        continue;
+                    }
+
+                    long requestCost = limit.GetCost(request);
+
+                    var limitCheckResult = await limit.IsExceededAsync(request, requestCost, this._counterStore, config.UniqueName, this._log);
+
+                    if (limitCheckResult == null)
+                    {
+                        // The request did not match this rule
+
+                        #region Telemetry
+                        string msg = "Request did not match this rule";
+                        activity?.AddTag("Result", msg);
+                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
+                        #endregion
+
+                        continue;
+                    }
+
+                    #region Telemetry
+                    activity?.AddTag("RequestCost", requestCost);
+                    limitCheckResult.AddTagsToActivity(activity);
+                    #endregion
+
+                    if ((limitCheckResult.RequestsRemaining < 0) && limit.MaxDelayInSeconds > 0)
+                    {
+                        #region Telemetry
+                        using var waitingActivity = ActivitySource.StartActivity($"ThrottlingTroll.Waiting");
+                        #endregion
+
+                        // Doing the delay logic
+                        while ((DateTimeOffset.UtcNow - dtStart).TotalSeconds <= limit.MaxDelayInSeconds)
+                        {
+                            if (!await limit.IsStillExceededAsync(this._counterStore, limitCheckResult.CounterId, request))
+                            {
+                                // Doing double-check
+                                limitCheckResult = await limit.IsExceededAsync(request, requestCost, this._counterStore, config.UniqueName, this._log);
+
+                                if (limitCheckResult.RequestsRemaining >= 0)
+                                {
+                                    break;
+                                }
+                            }
+
+                            await Task.Delay(this._sleepTimeSpan);
+                        }
+
+                        #region Telemetry
+                        if (limitCheckResult.RequestsRemaining >= 0)
+                        {
+                            waitingActivity?.SetStatus(ActivityStatusCode.Ok, "Waiting finished");
+                        }
+                        else
+                        {
+                            waitingActivity?.SetStatus(ActivityStatusCode.Error, "Waiting timed out");
+                        }
+                        #endregion
+                    }
+
+                    if (limitCheckResult.RequestsRemaining >= 0)
+                    {
+                        // Decrementing this counter at the end of request processing
+                        cleanupRoutines.Add(() => limit.OnRequestProcessingFinished(this._counterStore, limitCheckResult.CounterId, requestCost, this._log, request));
+                    }
+
+                    result.Add(limitCheckResult);
+
+                    #region Telemetry
+                    if (limitCheckResult.RequestsRemaining >= 0)
+                    {
+                        string msg = $"Requests remaining: {limitCheckResult.RequestsRemaining}";
+                        activity?.AddTag("Result", msg);
+                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
+
+                        activity?.SetStatus(ActivityStatusCode.Ok);
+                    }
+                    else
+                    {
+                        string msg = "Request limit exceeded";
+                        activity?.AddTag("Result", msg);
+                        activity?.SetStatus(ActivityStatusCode.Error, msg);
+                    }
+                    #endregion
+                }
+                catch (Exception ex)
+                {
+                    string msg = $"ThrottlingTroll failed. {ex}";
+                    this._log(LogLevel.Error, msg);
+
+                    #region Telemetry
+                    activity?.AddTag("Result", msg);
+                    activity?.SetStatus(ActivityStatusCode.Error, msg);
+
+                    FailuresCounter.Add(1, new TagList { { "throttlingtroll.rule", limit.GetNameForTelemetry() } });
+                    #endregion
+
+                    if (limit.ShouldThrowOnFailures)
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            if (allowListed)
+            {
+                this._log(LogLevel.Information, $"ThrottlingTroll allowlisted {request.Method} {request.UriWithoutQueryString}");
+            }
+
+            // Adding check results as an item to the HttpContext, so that client's code can use it
+            this.AppendToContextItem(request, LimitCheckResultsContextKey, result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Applies the CircuitBreaker logic
+        /// </summary>
+        protected internal async Task CheckAndBreakTheCircuit(IHttpRequestProxy request, IHttpResponseProxy response, Exception exception)
+        {
+            ThrottlingTrollConfig config;
+            try
+            {
+                config = await this.GetCurrentConfig();
+            }
+            catch (Exception ex)
+            {
+                this._log(LogLevel.Error, $"ThrottlingTroll failed to get its config. {ex}");
+
+                return;
+            }
+
+            if (config?.Rules == null)
+            {
+                return;
+            }
+
+            // Checking all CircuitBreaker rules that this request matches
+            foreach (var limit in config.Rules)
+            {
+                #region Telemetry
+                Activity activity = null;
+                #endregion
+
+                try
+                {
+                    var circuitBreakerMethod = limit.LimitMethod as CircuitBreakerRateLimitMethod;
+                    if (circuitBreakerMethod == null || !limit.IsMatch(request))
+                    {
+                        continue;
+                    }
+
+                    string uniqueCacheKey = limit.GetUniqueCacheKey(request, config.UniqueName);
+
+                    #region Telemetry
+                    activity = ActivitySource.StartActivity($"ThrottlingTroll.CircuitBreakerRule.{limit.GetNameForTelemetry()}");
+                    activity?.AddTag($"CounterId", uniqueCacheKey);
+                    limit.AddTagsToActivity(activity);
+                    #endregion
+
+                    if (circuitBreakerMethod.IsFailed(response, exception))
+                    {
+                        // Checking the failure count
+
+                        var now = DateTime.UtcNow;
+
+                        var ttl = now - TimeSpan.FromMilliseconds(now.Millisecond) + TimeSpan.FromSeconds(circuitBreakerMethod.IntervalInSeconds);
+
+                        // Better to use a separate counter for failures, because Trial mode increments the counter regardless of the output.
+                        // We don't want to count successes as failures, that would distort the picture.
+                        string failureCountCacheKey = $"{uniqueCacheKey}|CircuitBreakerFailureCount";
+
+                        long failureCount = await this._counterStore.IncrementAndGetAsync(failureCountCacheKey, 1, ttl, 1, request);
+
+                        if (failureCount > circuitBreakerMethod.PermitLimit)
+                        {
+                            // If failure limit is exceeded, placing this limit into Trial mode, which limits request rate to 1 request per trial interval
+                            CircuitBreakerRateLimitMethod.PutIntoTrial(uniqueCacheKey);
+
+                            #region Telemetry
+                            string msg = $"Went into trial mode";
+                            activity?.AddTag("Result", msg);
+                            activity?.AddTag($"FailureCount", failureCount);
+                            activity?.SetStatus(ActivityStatusCode.Error, msg);
+                            #endregion
+                        }
+                        else
+                        {
+                            #region Telemetry
+                            string msg = $"Failure count so far: {failureCount}";
+                            activity?.AddTag("Result", msg);
+                            activity?.AddTag($"FailureCount", failureCount);
+                            activity?.SetStatus(ActivityStatusCode.Ok, msg);
+                            #endregion
+                        }
+                    }
+                    else
+                    {
+                        // Just lifting the trial mode
+                        CircuitBreakerRateLimitMethod.ReleaseFromTrial(uniqueCacheKey);
+
+                        #region Telemetry
+                        string msg = "Released from trial mode";
+                        activity?.AddTag("Result", msg);
+                        activity?.SetStatus(ActivityStatusCode.Ok, msg);
+                        #endregion
+                    }
+                }
+                catch (Exception ex)
+                {
+                    string msg = $"ThrottlingTroll failed. {ex}";
+                    this._log(LogLevel.Error, msg);
+
+                    #region Telemetry
+                    activity?.AddTag("Result", msg);
+                    activity?.SetStatus(ActivityStatusCode.Error, msg);
+                    #endregion
+
+                    if (limit.ShouldThrowOnFailures)
+                    {
+                        throw;
+                    }
+                }
+                finally
+                {
+                    #region Telemetry
+                    activity?.Dispose();
+                    #endregion
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes this._getConfigTask and also makes it reinitialized every intervalToReloadConfigInSeconds
+        /// </summary>
+        private void InitGetConfigTask(Func<Task<ThrottlingTrollConfig>> getConfigFunc, int intervalToReloadConfigInSeconds)
+        {
+            if (this._disposed)
+            {
+                return;
+            }
+
+            if (intervalToReloadConfigInSeconds <= 0)
+            {
+                this._getConfigTask = getConfigFunc();
+
+                return;
+            }
+
+            var task = getConfigFunc();
+
+            task.ContinueWith(async t =>
+            {
+                #region Telemetry
+                if (t.IsFaulted)
+                {
+                    GetConfigFuncFailuresCounter.Add(1);
+                }
+                else if (t.IsCompletedSuccessfully)
+                {
+                    GetConfigFuncSuccessesCounter.Add(1);
+                }
+                #endregion
+
+                await Task.Delay(TimeSpan.FromSeconds(intervalToReloadConfigInSeconds));
+
+                this.InitGetConfigTask(getConfigFunc, intervalToReloadConfigInSeconds);
+            });
+
+            this._getConfigTask = task;
+        }
+
+        private void AppendToContextItem<T>(IHttpRequestProxy request, string key, List<T> list)
+        {
+            try
+            {
+                // Adding check results as an item to the HttpContext, so that client's code can use it
+                request.AppendToContextItem(key, list);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // At this point HttpContext might be already disposed, and in that case this happens.
+                this._log(LogLevel.Warning, $"ThrottlingTroll failed to populate request context with LimitCheckResults. {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Caching the current config value, so that we don't need to re-apply global settings every time
+        /// </summary>
+        private ThrottlingTrollConfig _currentConfig;
+    }
+}

--- a/tests/ThrottlingTroll.Tests/ThrottlingTrollCoreTests.cs
+++ b/tests/ThrottlingTroll.Tests/ThrottlingTrollCoreTests.cs
@@ -1,0 +1,427 @@
+using Moq;
+
+namespace ThrottlingTroll.Tests;
+
+[TestClass]
+public class ThrottlingTrollCoreTests
+{
+    [TestMethod]
+    public async Task IsIngressOrEgressExceededAsync_ThrowingGetConfigFunc_LogsExceptionAndContinues()
+    {
+        // Arrange
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        string errorMsg = "Ooops...";
+
+        bool logWasCalled = false;
+
+        var log = (LogLevel level, string msg) => 
+        {
+            logWasCalled = true;
+
+            Assert.AreEqual(LogLevel.Error, level);
+
+            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed to get its config. System.Exception: {errorMsg}"));
+        };
+
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), async () =>
+        {
+            throw new Exception(errorMsg);
+        },
+        null, null);
+
+        bool nextWasCalled = false;
+
+        // Act
+
+        var result = await troll.IsIngressOrEgressExceededAsync(requestMock.Object, null, async () => { 
+
+            nextWasCalled = true;
+        });
+
+        // Assert
+
+        Assert.AreEqual(0, result.Count);
+        Assert.IsTrue(logWasCalled);
+        Assert.IsTrue(nextWasCalled);
+    }
+
+    class FailingRule : ThrottlingTrollRule
+    {
+        public string ErrorMessage = "Oops...";
+
+        protected internal override Task<LimitCheckResult> IsExceededAsync(IHttpRequestProxy request, long cost, ICounterStore store, string configName, Action<LogLevel, string> log)
+        {
+            throw new Exception(this.ErrorMessage);
+        }
+    }
+
+    class SucceedingRule : ThrottlingTrollRule
+    {
+        public LimitCheckResult? Result;
+
+        protected internal override Task<LimitCheckResult> IsExceededAsync(IHttpRequestProxy request, long cost, ICounterStore store, string configName, Action<LogLevel, string> log)
+        {
+            this.Result = new LimitCheckResult(0, this, DateTimeOffset.Now.Millisecond, DateTimeOffset.Now.ToString());
+
+            return Task.FromResult(this.Result);
+        }
+    }
+
+    [TestMethod]
+    public async Task IsExceededAsync_ThrowOnErrorIsFalse_MethodCompletes()
+    {
+        // Arrange
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        var succeedingRule = new SucceedingRule();
+        var failingRule = new FailingRule { LimitMethod = new FixedWindowRateLimitMethod() { ShouldThrowOnFailures = false } };
+
+        bool logWasCalled = false;
+
+        var log = (LogLevel level, string msg) =>
+        {
+            logWasCalled = true;
+
+            Assert.AreEqual(LogLevel.Error, level);
+
+            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
+        };
+
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
+        {
+            var rules = new List<ThrottlingTrollRule>
+            {
+                succeedingRule,
+                failingRule,
+            };
+
+            return Task.FromResult(new ThrottlingTrollConfig { Rules = rules });
+        },
+        null, null);
+
+        // Act
+
+        var result = await troll.IsExceededAsync(requestMock.Object, new List<Func<Task>>());
+
+        // Assert
+
+        Assert.AreEqual(succeedingRule.Result, result.Single());
+
+        Assert.IsTrue(logWasCalled);
+    }
+
+    [TestMethod]
+    public async Task IsExceededAsync_ThrowOnErrorIsTrue_ExceptionThrown()
+    {
+        // Arrange
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        var succeedingRule = new SucceedingRule();
+        var failingRule = new FailingRule { LimitMethod = new FixedWindowRateLimitMethod() { ShouldThrowOnFailures = true } };
+
+        bool logWasCalled = false;
+
+        var log = (LogLevel level, string msg) =>
+        {
+            logWasCalled = true;
+
+            Assert.AreEqual(LogLevel.Error, level);
+
+            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
+        };
+
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
+        {
+            var rules = new List<ThrottlingTrollRule>
+            {
+                succeedingRule,
+                failingRule,
+            };
+
+            return Task.FromResult(new ThrottlingTrollConfig { Rules = rules });
+        },
+        null, null);
+
+        // Act
+
+        Func<Task<List<LimitCheckResult>>> act = () => troll.IsExceededAsync(requestMock.Object, new List<Func<Task>>());
+
+        // Assert
+
+        var resultException = await Assert.ThrowsExceptionAsync<Exception>(act);
+
+        Assert.AreEqual(failingRule.ErrorMessage, resultException.Message);
+
+        Assert.IsTrue(logWasCalled);
+    }
+
+    [TestMethod]
+    public async Task IsExceededAsync_TransientInternalError_AllRulesAreStillExecuted()
+    {
+        // Arrange
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        var failingRule = new FailingRule();
+        var succeedingRule = new SucceedingRule();
+
+        bool logWasCalled = false;
+
+        var log = (LogLevel level, string msg) =>
+        {
+            logWasCalled = true;
+
+            Assert.AreEqual(LogLevel.Error, level);
+
+            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
+        };
+
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
+        {
+            var rules = new List<ThrottlingTrollRule>
+            {
+                failingRule,
+                succeedingRule
+            };
+
+            return Task.FromResult(new ThrottlingTrollConfig { Rules = rules });
+        },
+        null, null);
+
+        // Act
+
+        var result = await troll.IsExceededAsync(requestMock.Object, new List<Func<Task>>());
+
+        // Assert
+
+        Assert.AreEqual(succeedingRule.Result, result.Single());
+
+        Assert.IsTrue(logWasCalled);
+    }
+
+    [TestMethod]
+    public async Task CheckAndBreakTheCircuit_ThrowingGetConfigFunc_LogsExceptionAndReturns()
+    {
+        // Arrange
+
+        string errorMsg = "Ooops...";
+
+        bool logWasCalled = false;
+
+        var log = (LogLevel level, string msg) =>
+        {
+            logWasCalled = true;
+
+            Assert.AreEqual(LogLevel.Error, level);
+
+            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed to get its config. System.Exception: {errorMsg}"));
+        };
+
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), async () =>
+        {
+            throw new Exception(errorMsg);
+        },
+        null, null);
+
+        // Act
+
+        await troll.CheckAndBreakTheCircuit(null, null, null);
+
+        // Assert
+
+        Assert.IsTrue(logWasCalled);
+    }
+
+    [TestMethod]
+    public async Task CheckAndBreakTheCircuit_EmptyConfig_DoesNothing()
+    {
+        // Arrange
+
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
+        {
+            return new ThrottlingTrollConfig();
+        },
+        null, null);
+
+        // Act
+
+        await troll.CheckAndBreakTheCircuit(null, null, null);
+
+        // Assert
+    }
+
+    class RuleWithFailingGetUniqueCacheKeyMethod : ThrottlingTrollRule
+    {
+        protected internal override string GetUniqueCacheKey(IHttpRequestProxy request, string configName)
+        {
+            throw new Exception("Oops...");
+        }
+    }
+
+    [TestMethod]
+    public async Task CheckAndBreakTheCircuit_NoCircuitBreakerRules_DoesNothing()
+    {
+        // Arrange
+
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
+        {
+            return new ThrottlingTrollConfig 
+            {
+                Rules = new List<ThrottlingTrollRule>
+                {
+                    new RuleWithFailingGetUniqueCacheKeyMethod()
+                }
+            };
+        },
+        null, null);
+
+        // Act
+
+        await troll.CheckAndBreakTheCircuit(null, null, null);
+
+        // Assert
+    }
+
+    [TestMethod]
+    public async Task CheckAndBreakTheCircuit_FailureLimitNotExceeded_DoesNothing()
+    {
+        // Arrange
+
+        var rule = new ThrottlingTrollRule
+        {
+            LimitMethod = new CircuitBreakerRateLimitMethod
+            {
+                PermitLimit = 3,
+                IntervalInSeconds = 1,
+                TrialIntervalInSeconds = 1,
+            }
+        };
+
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
+        {
+            return new ThrottlingTrollConfig
+            {
+                Rules = new List<ThrottlingTrollRule>
+                {
+                    rule
+                }
+            };
+        },
+        null, null);
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        var responseMock = new Mock<IHttpResponseProxy>();
+
+        responseMock.SetupGet(r => r.StatusCode).Returns(500);
+
+        // Act
+
+        await troll.CheckAndBreakTheCircuit(requestMock.Object, responseMock.Object, null);
+
+        // Assert
+
+        string uniqueCacheKey = rule.GetUniqueCacheKey(requestMock.Object, "");
+        bool isUnderTrial = CircuitBreakerRateLimitMethod.IsUnderTrial(uniqueCacheKey);
+
+        Assert.IsFalse(isUnderTrial);
+    }
+
+    [TestMethod]
+    public async Task CheckAndBreakTheCircuit_FailureLimitExceeded_PutsToTrialMode()
+    {
+        // Arrange
+
+        var rule = new ThrottlingTrollRule
+        {
+            LimitMethod = new CircuitBreakerRateLimitMethod
+            {
+                PermitLimit = 0,
+                IntervalInSeconds = 1,
+                TrialIntervalInSeconds = 1,
+            }
+        };
+
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
+        {
+            return new ThrottlingTrollConfig
+            {
+                Rules = new List<ThrottlingTrollRule>
+                {
+                    rule
+                }
+            };
+        },
+        null, null);
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        var responseMock = new Mock<IHttpResponseProxy>();
+
+        responseMock.SetupGet(r => r.StatusCode).Returns(500);
+
+        // Act
+
+        await troll.CheckAndBreakTheCircuit(requestMock.Object, responseMock.Object, null);
+
+        // Assert
+
+        string uniqueCacheKey = rule.GetUniqueCacheKey(requestMock.Object, "");
+        bool isUnderTrial = CircuitBreakerRateLimitMethod.IsUnderTrial(uniqueCacheKey);
+
+        Assert.IsTrue(isUnderTrial);
+    }
+
+    [TestMethod]
+    public async Task CheckAndBreakTheCircuit_TrialRequestSucceeds_ReleasesFromTrialMode()
+    {
+        // Arrange
+
+        var rule = new ThrottlingTrollRule
+        {
+            LimitMethod = new CircuitBreakerRateLimitMethod
+            {
+                PermitLimit = 3,
+                IntervalInSeconds = 1,
+                TrialIntervalInSeconds = 1,
+            }
+        };
+
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
+        {
+            return new ThrottlingTrollConfig
+            {
+                Rules = new List<ThrottlingTrollRule>
+                {
+                    rule
+                }
+            };
+        },
+        null, null);
+
+        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+
+        var responseMock = new Mock<IHttpResponseProxy>();
+
+        responseMock.SetupGet(r => r.StatusCode).Returns(200);
+
+        string uniqueCacheKey = rule.GetUniqueCacheKey(requestMock.Object, "");
+
+        CircuitBreakerRateLimitMethod.PutIntoTrial(uniqueCacheKey);
+
+        // Act
+
+        await troll.CheckAndBreakTheCircuit(requestMock.Object, responseMock.Object, null);
+
+        // Assert
+
+        bool isUnderTrial = CircuitBreakerRateLimitMethod.IsUnderTrial(uniqueCacheKey);
+
+        Assert.IsFalse(isUnderTrial);
+    }
+
+}

--- a/tests/ThrottlingTroll.Tests/ThrottlingTrollTests.cs
+++ b/tests/ThrottlingTroll.Tests/ThrottlingTrollTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using StackExchange.Redis;
 
 namespace ThrottlingTroll.Tests;
 
@@ -26,7 +25,7 @@ public class ThrottlingTrollTests
             Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed to get its config. System.Exception: {errorMsg}"));
         };
 
-        var troll = new ThrottlingTroll(log, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), async () =>
         {
             throw new Exception(errorMsg);
         },
@@ -91,7 +90,7 @@ public class ThrottlingTrollTests
             Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
         };
 
-        var troll = new ThrottlingTroll(log, new MemoryCacheCounterStore(), () =>
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
         {
             var rules = new List<ThrottlingTrollRule>
             {
@@ -135,7 +134,7 @@ public class ThrottlingTrollTests
             Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
         };
 
-        var troll = new ThrottlingTroll(log, new MemoryCacheCounterStore(), () =>
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
         {
             var rules = new List<ThrottlingTrollRule>
             {
@@ -181,7 +180,7 @@ public class ThrottlingTrollTests
             Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
         };
 
-        var troll = new ThrottlingTroll(log, new MemoryCacheCounterStore(), () =>
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
         {
             var rules = new List<ThrottlingTrollRule>
             {
@@ -222,7 +221,7 @@ public class ThrottlingTrollTests
             Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed to get its config. System.Exception: {errorMsg}"));
         };
 
-        var troll = new ThrottlingTroll(log, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), async () =>
         {
             throw new Exception(errorMsg);
         },
@@ -242,7 +241,7 @@ public class ThrottlingTrollTests
     {
         // Arrange
 
-        var troll = new ThrottlingTroll(null, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
         {
             return new ThrottlingTrollConfig();
         },
@@ -268,7 +267,7 @@ public class ThrottlingTrollTests
     {
         // Arrange
 
-        var troll = new ThrottlingTroll(null, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
         {
             return new ThrottlingTrollConfig 
             {
@@ -302,7 +301,7 @@ public class ThrottlingTrollTests
             }
         };
 
-        var troll = new ThrottlingTroll(null, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
         {
             return new ThrottlingTrollConfig
             {
@@ -347,7 +346,7 @@ public class ThrottlingTrollTests
             }
         };
 
-        var troll = new ThrottlingTroll(null, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
         {
             return new ThrottlingTrollConfig
             {
@@ -392,7 +391,7 @@ public class ThrottlingTrollTests
             }
         };
 
-        var troll = new ThrottlingTroll(null, new MemoryCacheCounterStore(), async () =>
+        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
         {
             return new ThrottlingTrollConfig
             {

--- a/tests/ThrottlingTroll.Tests/ThrottlingTrollTests.cs
+++ b/tests/ThrottlingTroll.Tests/ThrottlingTrollTests.cs
@@ -5,423 +5,90 @@ namespace ThrottlingTroll.Tests;
 [TestClass]
 public class ThrottlingTrollTests
 {
-    [TestMethod]
-    public async Task IsIngressOrEgressExceededAsync_ThrowingGetConfigFunc_LogsExceptionAndContinues()
+    class TestRule : ThrottlingTrollRule
     {
-        // Arrange
-
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
-
-        string errorMsg = "Ooops...";
-
-        bool logWasCalled = false;
-
-        var log = (LogLevel level, string msg) => 
-        {
-            logWasCalled = true;
-
-            Assert.AreEqual(LogLevel.Error, level);
-
-            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed to get its config. System.Exception: {errorMsg}"));
-        };
-
-        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), async () =>
-        {
-            throw new Exception(errorMsg);
-        },
-        null, null);
-
-        bool nextWasCalled = false;
-
-        // Act
-
-        var result = await troll.IsIngressOrEgressExceededAsync(requestMock.Object, null, async () => { 
-
-            nextWasCalled = true;
-        });
-
-        // Assert
-
-        Assert.AreEqual(0, result.Count);
-        Assert.IsTrue(logWasCalled);
-        Assert.IsTrue(nextWasCalled);
-    }
-
-    class FailingRule : ThrottlingTrollRule
-    {
-        public string ErrorMessage = "Oops...";
+        public LimitCheckResult Result = default!;
 
         protected internal override Task<LimitCheckResult> IsExceededAsync(IHttpRequestProxy request, long cost, ICounterStore store, string configName, Action<LogLevel, string> log)
         {
-            throw new Exception(this.ErrorMessage);
-        }
-    }
-
-    class SucceedingRule : ThrottlingTrollRule
-    {
-        public LimitCheckResult? Result;
-
-        protected internal override Task<LimitCheckResult> IsExceededAsync(IHttpRequestProxy request, long cost, ICounterStore store, string configName, Action<LogLevel, string> log)
-        {
-            this.Result = new LimitCheckResult(0, this, DateTimeOffset.Now.Millisecond, DateTimeOffset.Now.ToString());
-
             return Task.FromResult(this.Result);
         }
     }
 
     [TestMethod]
-    public async Task IsExceededAsync_ThrowOnErrorIsFalse_MethodCompletes()
+    public async Task WithThrottlingTroll_LimitNotExceeded_Succeeds()
     {
         // Arrange
 
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+        var rule = new TestRule();
+        rule.Result = new LimitCheckResult(1, rule, DateTimeOffset.Now.Millisecond, DateTimeOffset.Now.ToString());
 
-        var succeedingRule = new SucceedingRule();
-        var failingRule = new FailingRule { LimitMethod = new FixedWindowRateLimitMethod() { ShouldThrowOnFailures = false } };
-
-        bool logWasCalled = false;
-
-        var log = (LogLevel level, string msg) =>
-        {
-            logWasCalled = true;
-
-            Assert.AreEqual(LogLevel.Error, level);
-
-            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
-        };
-
-        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
-        {
-            var rules = new List<ThrottlingTrollRule>
-            {
-                succeedingRule,
-                failingRule,
-            };
-
-            return Task.FromResult(new ThrottlingTrollConfig { Rules = rules });
-        },
-        null, null);
+        var troll = new ThrottlingTroll(new ThrottlingTrollConfig { Rules = new[] { rule } });
+        string normalResult = DateTimeOffset.Now.ToString();
 
         // Act
 
-        var result = await troll.IsExceededAsync(requestMock.Object, new List<Func<Task>>());
+        var result = await troll.WithThrottlingTroll(() => Task.FromResult(normalResult), async ctx =>
+        {
+            Assert.Fail("onLimitExceeded should not be called");
+            return "should not be called";
+        });
 
         // Assert
 
-        Assert.AreEqual(succeedingRule.Result, result.Single());
-
-        Assert.IsTrue(logWasCalled);
+        Assert.AreEqual(normalResult, result);
     }
 
     [TestMethod]
-    public async Task IsExceededAsync_ThrowOnErrorIsTrue_ExceptionThrown()
+    public async Task WithThrottlingTroll_LimitExceeded_InvokesOnLimitExceeded()
     {
         // Arrange
 
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+        var rule = new TestRule();
+        rule.Result = new LimitCheckResult(-1, rule, DateTimeOffset.Now.Millisecond, DateTimeOffset.Now.ToString());
 
-        var succeedingRule = new SucceedingRule();
-        var failingRule = new FailingRule { LimitMethod = new FixedWindowRateLimitMethod() { ShouldThrowOnFailures = true } };
-
-        bool logWasCalled = false;
-
-        var log = (LogLevel level, string msg) =>
-        {
-            logWasCalled = true;
-
-            Assert.AreEqual(LogLevel.Error, level);
-
-            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
-        };
-
-        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
-        {
-            var rules = new List<ThrottlingTrollRule>
-            {
-                succeedingRule,
-                failingRule,
-            };
-
-            return Task.FromResult(new ThrottlingTrollConfig { Rules = rules });
-        },
-        null, null);
+        var troll = new ThrottlingTroll(new ThrottlingTrollConfig { Rules = new[] { rule } });
+        string limitExceededResult = DateTimeOffset.Now.ToString();
 
         // Act
 
-        Func<Task<List<LimitCheckResult>>> act = () => troll.IsExceededAsync(requestMock.Object, new List<Func<Task>>());
+        var result = await troll.WithThrottlingTroll(() => Task.FromResult("should not be returned"), async ctx => 
+        {
+            Assert.AreEqual(ctx.ExceededLimit.Rule, rule);
+
+            return limitExceededResult;
+        });
 
         // Assert
 
-        var resultException = await Assert.ThrowsExceptionAsync<Exception>(act);
-
-        Assert.AreEqual(failingRule.ErrorMessage, resultException.Message);
-
-        Assert.IsTrue(logWasCalled);
+        Assert.AreEqual(limitExceededResult, result);
     }
+
 
     [TestMethod]
-    public async Task IsExceededAsync_TransientInternalError_AllRulesAreStillExecuted()
+    public async Task WithThrottlingTroll_LimitExceeded_ContinuesAsNormal()
     {
         // Arrange
 
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
+        var rule = new TestRule();
+        rule.Result = new LimitCheckResult(-1, rule, DateTimeOffset.Now.Millisecond, DateTimeOffset.Now.ToString());
 
-        var failingRule = new FailingRule();
-        var succeedingRule = new SucceedingRule();
-
-        bool logWasCalled = false;
-
-        var log = (LogLevel level, string msg) =>
-        {
-            logWasCalled = true;
-
-            Assert.AreEqual(LogLevel.Error, level);
-
-            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed. System.Exception: {failingRule.ErrorMessage}"));
-        };
-
-        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), () =>
-        {
-            var rules = new List<ThrottlingTrollRule>
-            {
-                failingRule,
-                succeedingRule
-            };
-
-            return Task.FromResult(new ThrottlingTrollConfig { Rules = rules });
-        },
-        null, null);
+        var troll = new ThrottlingTroll(new ThrottlingTrollConfig { Rules = new[] { rule } });
+        string normalResult = DateTimeOffset.Now.ToString();
 
         // Act
 
-        var result = await troll.IsExceededAsync(requestMock.Object, new List<Func<Task>>());
+        var result = await troll.WithThrottlingTroll(() => Task.FromResult(normalResult), async ctx =>
+        {
+            Assert.AreEqual(ctx.ExceededLimit.Rule, rule);
+
+            ctx.ShouldContinueAsNormal = true;
+
+            return "should not be returned";
+        });
 
         // Assert
 
-        Assert.AreEqual(succeedingRule.Result, result.Single());
-
-        Assert.IsTrue(logWasCalled);
+        Assert.AreEqual(normalResult, result);
     }
-
-    [TestMethod]
-    public async Task CheckAndBreakTheCircuit_ThrowingGetConfigFunc_LogsExceptionAndReturns()
-    {
-        // Arrange
-
-        string errorMsg = "Ooops...";
-
-        bool logWasCalled = false;
-
-        var log = (LogLevel level, string msg) =>
-        {
-            logWasCalled = true;
-
-            Assert.AreEqual(LogLevel.Error, level);
-
-            Assert.IsTrue(msg.StartsWith($"ThrottlingTroll failed to get its config. System.Exception: {errorMsg}"));
-        };
-
-        var troll = new ThrottlingTrollCore(log, new MemoryCacheCounterStore(), async () =>
-        {
-            throw new Exception(errorMsg);
-        },
-        null, null);
-
-        // Act
-
-        await troll.CheckAndBreakTheCircuit(null, null, null);
-
-        // Assert
-
-        Assert.IsTrue(logWasCalled);
-    }
-
-    [TestMethod]
-    public async Task CheckAndBreakTheCircuit_EmptyConfig_DoesNothing()
-    {
-        // Arrange
-
-        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
-        {
-            return new ThrottlingTrollConfig();
-        },
-        null, null);
-
-        // Act
-
-        await troll.CheckAndBreakTheCircuit(null, null, null);
-
-        // Assert
-    }
-
-    class RuleWithFailingGetUniqueCacheKeyMethod : ThrottlingTrollRule
-    {
-        protected internal override string GetUniqueCacheKey(IHttpRequestProxy request, string configName)
-        {
-            throw new Exception("Oops...");
-        }
-    }
-
-    [TestMethod]
-    public async Task CheckAndBreakTheCircuit_NoCircuitBreakerRules_DoesNothing()
-    {
-        // Arrange
-
-        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
-        {
-            return new ThrottlingTrollConfig 
-            {
-                Rules = new List<ThrottlingTrollRule>
-                {
-                    new RuleWithFailingGetUniqueCacheKeyMethod()
-                }
-            };
-        },
-        null, null);
-
-        // Act
-
-        await troll.CheckAndBreakTheCircuit(null, null, null);
-
-        // Assert
-    }
-
-    [TestMethod]
-    public async Task CheckAndBreakTheCircuit_FailureLimitNotExceeded_DoesNothing()
-    {
-        // Arrange
-
-        var rule = new ThrottlingTrollRule
-        {
-            LimitMethod = new CircuitBreakerRateLimitMethod
-            {
-                PermitLimit = 3,
-                IntervalInSeconds = 1,
-                TrialIntervalInSeconds = 1,
-            }
-        };
-
-        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
-        {
-            return new ThrottlingTrollConfig
-            {
-                Rules = new List<ThrottlingTrollRule>
-                {
-                    rule
-                }
-            };
-        },
-        null, null);
-
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
-
-        var responseMock = new Mock<IHttpResponseProxy>();
-
-        responseMock.SetupGet(r => r.StatusCode).Returns(500);
-
-        // Act
-
-        await troll.CheckAndBreakTheCircuit(requestMock.Object, responseMock.Object, null);
-
-        // Assert
-
-        string uniqueCacheKey = rule.GetUniqueCacheKey(requestMock.Object, "");
-        bool isUnderTrial = CircuitBreakerRateLimitMethod.IsUnderTrial(uniqueCacheKey);
-
-        Assert.IsFalse(isUnderTrial);
-    }
-
-    [TestMethod]
-    public async Task CheckAndBreakTheCircuit_FailureLimitExceeded_PutsToTrialMode()
-    {
-        // Arrange
-
-        var rule = new ThrottlingTrollRule
-        {
-            LimitMethod = new CircuitBreakerRateLimitMethod
-            {
-                PermitLimit = 0,
-                IntervalInSeconds = 1,
-                TrialIntervalInSeconds = 1,
-            }
-        };
-
-        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
-        {
-            return new ThrottlingTrollConfig
-            {
-                Rules = new List<ThrottlingTrollRule>
-                {
-                    rule
-                }
-            };
-        },
-        null, null);
-
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
-
-        var responseMock = new Mock<IHttpResponseProxy>();
-
-        responseMock.SetupGet(r => r.StatusCode).Returns(500);
-
-        // Act
-
-        await troll.CheckAndBreakTheCircuit(requestMock.Object, responseMock.Object, null);
-
-        // Assert
-
-        string uniqueCacheKey = rule.GetUniqueCacheKey(requestMock.Object, "");
-        bool isUnderTrial = CircuitBreakerRateLimitMethod.IsUnderTrial(uniqueCacheKey);
-
-        Assert.IsTrue(isUnderTrial);
-    }
-
-    [TestMethod]
-    public async Task CheckAndBreakTheCircuit_TrialRequestSucceeds_ReleasesFromTrialMode()
-    {
-        // Arrange
-
-        var rule = new ThrottlingTrollRule
-        {
-            LimitMethod = new CircuitBreakerRateLimitMethod
-            {
-                PermitLimit = 3,
-                IntervalInSeconds = 1,
-                TrialIntervalInSeconds = 1,
-            }
-        };
-
-        var troll = new ThrottlingTrollCore(null, new MemoryCacheCounterStore(), async () =>
-        {
-            return new ThrottlingTrollConfig
-            {
-                Rules = new List<ThrottlingTrollRule>
-                {
-                    rule
-                }
-            };
-        },
-        null, null);
-
-        var requestMock = new Mock<IIncomingHttpRequestProxy>();
-
-        var responseMock = new Mock<IHttpResponseProxy>();
-
-        responseMock.SetupGet(r => r.StatusCode).Returns(200);
-
-        string uniqueCacheKey = rule.GetUniqueCacheKey(requestMock.Object, "");
-
-        CircuitBreakerRateLimitMethod.PutIntoTrial(uniqueCacheKey);
-
-        // Act
-
-        await troll.CheckAndBreakTheCircuit(requestMock.Object, responseMock.Object, null);
-
-        // Assert
-
-        bool isUnderTrial = CircuitBreakerRateLimitMethod.IsUnderTrial(uniqueCacheKey);
-
-        Assert.IsFalse(isUnderTrial);
-    }
-
 }


### PR DESCRIPTION
Now an instance of ThrottlingTroll can be instantiated directly.
Also an instance of IThrottlingTroll can be injected into DI container.

Then you can use IThrottlingTroll.WithThrottlingTroll() to limit any arbitrary piece of code.